### PR TITLE
Improvements

### DIFF
--- a/experiments/mandel_runscript_1.py
+++ b/experiments/mandel_runscript_1.py
@@ -41,7 +41,7 @@ class Geometry(pp.SolutionStrategy):
     def bc_values_pressure(self, boundary_grid):
         vals = super().bc_values_pressure(boundary_grid)
         sides = self.domain_boundary_sides(boundary_grid)
-        x = self.params["setup"]["high_boundary_pressure_ratio"]
+        x = self.params["linear_solver_config"]["high_boundary_pressure_ratio"]
         vals[sides.east] *= x
         return vals
 
@@ -96,7 +96,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/experiments/mandel_runscript_2.py
+++ b/experiments/mandel_runscript_2.py
@@ -96,7 +96,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/experiments/mandel_runscript_3.py
+++ b/experiments/mandel_runscript_3.py
@@ -103,7 +103,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/experiments/models.py
+++ b/experiments/models.py
@@ -56,7 +56,7 @@ class Physics(DimensionDependentPermeability, SpecificStorage, Poromechanics):
         return result
 
     def fluid_mass(self, subdomains: list[pp.Grid]) -> pp.ad.Operator:
-        physics_type = self.params["setup"]["physics"]
+        physics_type = self.params["linear_solver_config"]["physics"]
         if physics_type == 1:
             return super().fluid_mass(subdomains)
         elif physics_type == 0:
@@ -64,7 +64,7 @@ class Physics(DimensionDependentPermeability, SpecificStorage, Poromechanics):
         raise ValueError(physics_type)
 
     def permeability(self, subdomains):
-        physics_type = self.params["setup"]["physics"]
+        physics_type = self.params["linear_solver_config"]["physics"]
         permeability = self.params['setup'].get('permeability', 1)
 
         if permeability == 0:

--- a/src/FTHM_Solver/fixed_stress.py
+++ b/src/FTHM_Solver/fixed_stress.py
@@ -189,9 +189,6 @@ def get_fs_fractures_analytical(model: pp.PorePyModel) -> sps.spmatrix:
     dt = model.time_manager.dt
     val /= dt
 
-    intersect_zeros = np.zeros(sum(f.num_cells for f in intersections))
-    val = np.concatenate([val, intersect_zeros])
-
     return sps.diags(val)
 
 

--- a/src/FTHM_Solver/hm_solver.py
+++ b/src/FTHM_Solver/hm_solver.py
@@ -370,7 +370,7 @@ class IterativeHMSolver(IterativeLinearSolver):
             return super().solve_linear_system()
 
     def make_solver_scheme(self) -> KSPScheme | LinearTransformedScheme:
-        solver_type = self.params["setup"]["solver"]
+        solver_type = self.params.get("linear_solver_config", {}).get("solver", 3)
 
         if solver_type == 2:  # GMRES + AMG
             return KSPScheme(

--- a/src/FTHM_Solver/hm_solver.py
+++ b/src/FTHM_Solver/hm_solver.py
@@ -354,21 +354,6 @@ class IterativeHMSolver(IterativeLinearSolver):
         self.bmat.mat = mat
         self.linear_system = mat, rhs
 
-    def solve_linear_system(self) -> np.ndarray:
-        rhs = self.linear_system[1]
-        if not np.all(np.isfinite(rhs)):
-            self._linear_solve_stats.krylov_iters = 0
-            result = np.zeros_like(rhs)
-            result[:] = np.nan
-            return result
-
-        solver_type = self.params["setup"]["solver"]
-        direct = solver_type == 0
-        if direct:
-            return scipy.sparse.linalg.spsolve(*self.linear_system)
-        else:
-            return super().solve_linear_system()
-
     def make_solver_scheme(self) -> KSPScheme | LinearTransformedScheme:
         solver_type = self.params.get("linear_solver_config", {}).get("solver", 3)
 

--- a/src/FTHM_Solver/iterative_solver.py
+++ b/src/FTHM_Solver/iterative_solver.py
@@ -146,7 +146,9 @@ class IterativeLinearSolver(pp.PorePyModel):
         #     result = np.zeros_like(rhs)
         #     return result
 
-        if self.params["setup"].get("save_matrix", False):
+        config = self.params.get("linear_solver_config", {})
+
+        if config.get("save_matrix", False):
             self.save_matrix_state()
 
         scheme = self.make_solver_scheme()
@@ -158,8 +160,10 @@ class IterativeLinearSolver(pp.PorePyModel):
             solver = scheme.make_solver(bmat)
         except:
             self.save_matrix_state()
-            raise ValueError("Solver construction failed")
-        print("Construction took:", round(time.time() - t0, 2))
+            raise ValueError("Solver construction failed") from e
+
+        if config.get("logging", False):
+            print("Construction took:", round(time.time() - t0, 2))
 
         # Permute the rhs groups to match mat_permuted.
         rhs_local = bmat.project_rhs_to_local(rhs)
@@ -170,8 +174,10 @@ class IterativeLinearSolver(pp.PorePyModel):
             sol_local = solver.solve(rhs_local)
         except:
             self.save_matrix_state()
-            raise ValueError("Solver solve failed")
-        print("Solve took:", round(time.time() - t0, 2))
+            raise ValueError("Solver solve failed") from e
+        
+        if config.get("logging", False):
+            print("Solve took:", round(time.time() - t0, 2))
 
         info = solver.ksp.getConvergedReason()
 

--- a/src/FTHM_Solver/iterative_solver.py
+++ b/src/FTHM_Solver/iterative_solver.py
@@ -1,6 +1,6 @@
 import sys
 from functools import cached_property
-from typing import Sequence, Callable
+from typing import Sequence
 import time
 
 import scipy.sparse as sps
@@ -9,10 +9,10 @@ import porepy as pp
 
 from .block_matrix import BlockMatrixStorage, FieldSplitScheme, KSPScheme
 
-from .stats import LinearSolveStats
+from .stats import LinearSolveStats, StatisticsSavingMixin
 
 
-class IterativeLinearSolver(pp.PorePyModel):
+class IterativeLinearSolver(StatisticsSavingMixin, pp.PorePyModel):
     """Mixin for iterative linear solvers."""
 
     nd: int
@@ -20,8 +20,6 @@ class IterativeLinearSolver(pp.PorePyModel):
     params: dict
     equation_system: pp.ad.EquationSystem
     linear_system: tuple[sps.spmatrix, np.ndarray]
-
-    save_matrix_state: Callable[..., None]
 
     _linear_solve_stats = LinearSolveStats()
     """A placeholder to statistics. The solver mixin only writes in it, not reads."""
@@ -158,7 +156,7 @@ class IterativeLinearSolver(pp.PorePyModel):
         t0 = time.time()
         try:
             solver = scheme.make_solver(bmat)
-        except:
+        except Exception as e:
             self.save_matrix_state()
             raise ValueError("Solver construction failed") from e
 
@@ -172,7 +170,7 @@ class IterativeLinearSolver(pp.PorePyModel):
         sol_local = solver.solve(rhs_local)
         try:
             sol_local = solver.solve(rhs_local)
-        except:
+        except Exception as e:
             self.save_matrix_state()
             raise ValueError("Solver solve failed") from e
         

--- a/src/FTHM_Solver/plot_utils.py
+++ b/src/FTHM_Solver/plot_utils.py
@@ -15,7 +15,7 @@ from numpy.linalg import norm
 from scipy.sparse import bmat
 from scipy.sparse.linalg import LinearOperator
 
-from stats import LinearSolveStats, dump_json
+from FTHM_Solver.stats import LinearSolveStats, dump_json
 
 if TYPE_CHECKING:
     from .block_matrix import (

--- a/src/FTHM_Solver/stats.py
+++ b/src/FTHM_Solver/stats.py
@@ -118,10 +118,10 @@ class StatisticsSavingMixin(ContactIndicators):
     def before_nonlinear_iteration(self) -> None:
         self._linear_solve_stats = LinearSolveStats()
         super().before_nonlinear_iteration()
-        self.collect_stats_sticking_sliding_open()
-        self.collect_stats_ut_mismatch()
-        self.collect_stats_coulomb_mismatch()
-        self.collect_stats_u_lambda_max()
+        # self.collect_stats_sticking_sliding_open()
+        # self.collect_stats_ut_mismatch()
+        # self.collect_stats_coulomb_mismatch()
+        # self.collect_stats_u_lambda_max()
 
     def after_nonlinear_iteration(self, solution_vector: np.ndarray) -> None:
         config = self.params.get("linear_solver_config", {})

--- a/src/FTHM_Solver/stats.py
+++ b/src/FTHM_Solver/stats.py
@@ -135,7 +135,7 @@ class StatisticsSavingMixin(ContactIndicators):
         # if self.params["linear_solver_config"].get("save_matrix", False):
         #     self.save_matrix_state()
         dump_json(self.simulation_name() + ".json", self.statistics)
-        from plot_utils import write_dofs_info
+        from FTHM_Solver.plot_utils import write_dofs_info
 
         write_dofs_info(self)
         super().after_nonlinear_iteration(solution_vector)

--- a/src/FTHM_Solver/thm_solver.py
+++ b/src/FTHM_Solver/thm_solver.py
@@ -89,12 +89,17 @@ class THMSolver(IterativeHMSolver):
         """Prepares the groups of variables in the specific order, that we will use in
         the block Jacobian to access the submatrices:
 
-        `J[x, 0]` - matrix pressure variable;
-        `J[x, 1]` - matrix displacement variable;
-        `J[x, 2]` - lower-dim pressure variable;
-        `J[x, 3]` - interface Darcy flux variable;
-        `J[x, 4]` - contact traction variable;
-        `J[x, 5]` - interface displacement variable;
+        `J[x, 0]` - contact traction variable;
+        `J[x, 1]` - interface Darcy flux;
+        `J[x, 2]` - interface fluxes temperature;
+        `J[x, 3]` - displacement in ambient dimension;
+        `J[x, 4]` - displacement on interfaces;
+        `J[x, 5]` - pressure in ambient dimension;
+        `J[x, 6]` - pressure in fractures;
+        `J[x, 7]` - pressure in interfaces;
+        `J[x, 8]` - temperature in ambient dimension;
+        `J[x, 9]` - temperature in fractures;
+        `J[x, 10]` - temperature in interfaces;
 
         This index is not equivalen to PorePy model natural ordering. Constructed when
         first accessed.
@@ -205,9 +210,11 @@ class THMSolver(IterativeHMSolver):
                 "pc_fieldsplit_type": "additive",
             },
             elim_options={
-                "pc_type": "hypre",
-                "pc_hypre_type": "boomeramg",
-                "pc_hypre_boomeramg_strong_threshold": 0.7,
+                # "pc_type": "hypre",
+                # "pc_hypre_type": "boomeramg",
+                # "pc_hypre_boomeramg_strong_threshold": 0.7,
+                "pc_type": "gamg",
+                "pc_gamg_threshold": 0.02,
             },
             complement=PetscFieldSplitScheme(
                 groups=temp,
@@ -244,17 +251,15 @@ class THMSolver(IterativeHMSolver):
                 block_size=2,
             ),
             elim_options={
-                "python_pc_type": "hypre",
-                "python_pc_hypre_type": "boomeramg",
-                "python_pc_hypre_boomeramg_strong_threshold": 0.7,
-                "python_pc_hypre_boomeramg_P_max": 16,
-                # "python_pc_type": "hmg",
-                # "python_hmg_inner_pc_type": "hypre",
-                # "python_hmg_inner_pc_hypre_type": "boomeramg",
-                # "python_hmg_inner_pc_hypre_boomeramg_strong_threshold": 0.7,
-                # # "python_pc_hypre_boomeramg_P_max": 16,
-                # "python_mg_levels_ksp_type": "richardson",
-                # "python_mg_levels_ksp_max_it": 1,
+                # "python_pc_type": "hypre",
+                # "python_pc_hypre_type": "boomeramg",
+                # "python_pc_hypre_boomeramg_strong_threshold": 0.7,
+                # "python_pc_hypre_boomeramg_P_max": 16,
+                "python_pc_type": "gamg",
+                "python_pc_gamg_threshold": 0.02,
+                "python_mg_levels_ksp_type": "richardson",
+                "python_mg_levels_ksp_max_it": 4,
+                "python_mg_levels_pc_type": "sor",
             },
         )
 
@@ -382,13 +387,13 @@ class THMSolver(IterativeHMSolver):
                                     # 'pc_hypre_boomeramg_max_row_sum': 1.0,
                                     # # "pc_hypre_boomeramg_smooth_type": "Euclid",
                                     "pc_type": "hmg",
-                                    "hmg_inner_pc_type": "hypre",
-                                    "hmg_inner_pc_hypre_type": "boomeramg",
-                                    "hmg_inner_pc_hypre_boomeramg_strong_threshold": 0.7,
+                                    "hmg_inner_pc_type": "gamg",
+                                    "hmg_inner_pc_gamg_threshold": 0.02,
+                                    # "hmg_inner_pc_hypre_type": "boomeramg",
+                                    # "hmg_inner_pc_hypre_boomeramg_strong_threshold": 0.7,
                                     "mg_levels_ksp_type": "richardson",
                                     "mg_levels_ksp_max_it": 2,
-                                    # 3D model has bad grid
-                                    "mg_levels_pc_type": "ilu" if nd == 3 else "sor",
+                                    "mg_levels_pc_type": "ilu",
                                 }
                             ),
                             keep_options={},
@@ -456,7 +461,6 @@ class THMSolver(IterativeHMSolver):
                             "ksp_type": "gmres",
                             "ksp_rtol": inner_rtol,
                             "ksp_pc_side": "right",
-                            "ksp_monitor": None,
                             #
                             "pc_type": "ilu",
                         }
@@ -473,9 +477,11 @@ class THMSolver(IterativeHMSolver):
                                     "ksp_pc_side": "right",
                                     #
                                     "pc_type": "hmg",
-                                    "hmg_inner_pc_type": "hypre",
-                                    "hmg_inner_pc_hypre_type": "boomeramg",
-                                    "hmg_inner_pc_hypre_boomeramg_strong_threshold": 0.7,
+                                    "hmg_inner_pc_type": "gamg",
+                                    "hmg_inner_pc_gamg_threshold": 0.02,
+                                    # "hmg_inner_pc_type": "hypre",
+                                    # "hmg_inner_pc_hypre_type": "boomeramg",
+                                    # "hmg_inner_pc_hypre_boomeramg_strong_threshold": 0.7,
                                     "mg_levels_ksp_type": "richardson",
                                     "mg_levels_ksp_max_it": 2,
                                     # 3D model has bad grid

--- a/thermal/models.py
+++ b/thermal/models.py
@@ -55,7 +55,7 @@ class Physics(CubicLawPermeability, Thermoporomechanics):
 
     def initial_condition(self) -> None:
         super().initial_condition()
-        if self.params["setup"]["steady_state"]:
+        if self.params["linear_solver_config"]["steady_state"]:
             num_cells = sum([sd.num_cells for sd in self.mdg.subdomains()])
             val = self.reference_variable_values.pressure * np.ones(num_cells)
             for time_step_index in self.time_step_indices:
@@ -87,7 +87,7 @@ class Physics(CubicLawPermeability, Thermoporomechanics):
                     iterate_index=iterate_index,
                 )
         else:
-            initial_state = self.params["setup"]["initial_state"]
+            initial_state = self.params["linear_solver_config"]["initial_state"]
             if initial_state != "ignore":
                 vals = np.load(initial_state)
                 self.equation_system.set_variable_values(vals, time_step_index=0)

--- a/thermal/thermal_runscript_1.py
+++ b/thermal/thermal_runscript_1.py
@@ -56,7 +56,7 @@ class Geometry(pp.SolutionStrategy):
     def bc_values_pressure(self, boundary_grid):
         vals = super().bc_values_pressure(boundary_grid)
         sides = self.domain_boundary_sides(boundary_grid)
-        x = self.params["setup"]["high_boundary_pressure_ratio"]
+        x = self.params["linear_solver_config"]["high_boundary_pressure_ratio"]
         vals[sides.east] *= x
         return vals
 
@@ -118,7 +118,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/thermal/thermal_runscript_2.py
+++ b/thermal/thermal_runscript_2.py
@@ -117,7 +117,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/thermal/thermal_runscript_3.py
+++ b/thermal/thermal_runscript_3.py
@@ -125,7 +125,7 @@ def make_model(setup: dict):
     specific_storage = 1 / (lame + 2 / 3 * shear) * (biot - porosity) * (1 - biot)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "material_constants": {
             "solid": pp.SolidConstants(
                 shear_modulus=shear,  # [Pa]

--- a/thermal/thermal_runscript_4.py
+++ b/thermal/thermal_runscript_4.py
@@ -54,7 +54,7 @@ class Geometry(pp.PorePyModel):
         return np.concatenate([zeros_ambient, src_frac, zeros_lower])
 
     def fluid_source_mass_rate(self):
-        if self.params["setup"]["steady_state"]:
+        if self.params["linear_solver_config"]["steady_state"]:
             return 0
         else:
             return self.units.convert_units(1e1, "kg * s^-1")
@@ -70,7 +70,7 @@ class Geometry(pp.PorePyModel):
         src *= self.fluid_source_mass_rate()
         cv = self.fluid.components[0].specific_heat_capacity
         t_inj = 40
-        if self.params["setup"].get("isothermal", False):
+        if self.params["linear_solver_config"].get("isothermal", False):
             t_inj = self.reference_variable_values.temperature - 273
 
         t_inj = (
@@ -117,7 +117,7 @@ class Geometry(pp.PorePyModel):
         vals = self.equation_system.get_variable_values(time_step_index=0)
         name = f"{self.simulation_name()}_endstate_{int(time.time() * 1000)}.npy"
         print("Saving", name)
-        self.params["setup"]["end_state_filename"] = name
+        self.params["linear_solver_config"]["end_state_filename"] = name
         np.save(name, vals)
 
 
@@ -125,9 +125,9 @@ class Setup(Geometry, THMSolver, StatisticsSavingMixin, Physics):
 
     def simulation_name(self):
         name = super().simulation_name()
-        if self.params["setup"].get("isothermal", False):
+        if self.params["linear_solver_config"].get("isothermal", False):
             name = f"{name}_isothermal"
-        if (x := self.params["setup"].get("thermal_conductivity_multiplier", 1)) != 1:
+        if (x := self.params["linear_solver_config"].get("thermal_conductivity_multiplier", 1)) != 1:
             name = f"{name}_diffusion={x}"
         if (x := self.params['setup'].get('friction_coef', None)):
             name = f"{name}_friction={x}"
@@ -158,7 +158,7 @@ def make_model(setup: dict):
     friction_coef = setup.get('friction_coef', 0.577)
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "folder_name": "visualization_2d",
         "material_constants": {
             "solid": pp.SolidConstants(

--- a/thermal/thermal_runscript_4_test.py
+++ b/thermal/thermal_runscript_4_test.py
@@ -58,7 +58,7 @@ class Geometry(pp.SolutionStrategy):
         return np.concatenate([zeros_ambient, src_frac, zeros_lower])
 
     def fluid_source_mass_rate(self):
-        if self.params["setup"]["steady_state"]:
+        if self.params["linear_solver_config"]["steady_state"]:
             return 0
         else:
             return self.units.convert_units(1e1, "kg * s^-1")
@@ -98,7 +98,7 @@ class Geometry(pp.SolutionStrategy):
         vals = self.equation_system.get_variable_values(time_step_index=0)
         name = f"{self.simulation_name()}_endstate_{int(time.time() * 1000)}.npy"
         print("Saving", name)
-        self.params["setup"]["end_state_filename"] = name
+        self.params["linear_solver_config"]["end_state_filename"] = name
         np.save(name, vals)
 
 
@@ -127,7 +127,7 @@ def make_model(setup: dict):
     porosity = 1.3e-2  # probably on the low side
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "folder_name": "visualization_2d_test",
         "material_constants": {
             "solid": pp.SolidConstants(

--- a/thermal/thermal_runscript_5.py
+++ b/thermal/thermal_runscript_5.py
@@ -68,7 +68,7 @@ class Geometry(pp.PorePyModel):
         return np.concatenate([zeros_ambient, src_frac, zeros_lower])
 
     def fluid_source_mass_rate(self):
-        if self.params["setup"]["steady_state"]:
+        if self.params["linear_solver_config"]["steady_state"]:
             return 0
         else:
             return self.units.convert_units(1e3, "kg * s^-1")
@@ -203,7 +203,7 @@ class Geometry(pp.PorePyModel):
         vals = self.equation_system.get_variable_values(time_step_index=0)
         name = f"{self.simulation_name()}_endstate_{int(time.time() * 1000)}.npy"
         print("Saving", name)
-        self.params["setup"]["end_state_filename"] = name
+        self.params["linear_solver_config"]["end_state_filename"] = name
         np.save(name, vals)
 
 
@@ -230,7 +230,7 @@ def make_model(setup: dict):
     porosity = 1.3e-2  # probably on the low side
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "folder_name": "visualization_3d",
         "material_constants": {
             "solid": pp.SolidConstants(

--- a/thermal/thermal_runscript_nofrac.py
+++ b/thermal/thermal_runscript_nofrac.py
@@ -37,7 +37,7 @@ class Geometry(pp.SolutionStrategy):
 
     def bc_type_fourier_flux(self, sd: pp.Grid) -> pp.BoundaryCondition:
         boundary_faces = self.domain_boundary_sides(sd).all_bf
-        if self.params["setup"].get("thermal_diffusion_bc") == "noflux":
+        if self.params["linear_solver_config"].get("thermal_diffusion_bc") == "noflux":
             return pp.BoundaryCondition(sd, boundary_faces, "neu")
         return pp.BoundaryCondition(sd, boundary_faces, "dir")
 
@@ -58,7 +58,7 @@ class Geometry(pp.SolutionStrategy):
         return np.concatenate([src_mat, zeros_frac, zeros_lower])
 
     def fluid_source_mass_rate(self):
-        if self.params["setup"]["steady_state"]:
+        if self.params["linear_solver_config"]["steady_state"]:
             return 0
         else:
             return self.units.convert_units(1e1, "kg * s^-1")
@@ -98,7 +98,7 @@ class Geometry(pp.SolutionStrategy):
         vals = self.equation_system.get_variable_values(time_step_index=0)
         name = f"{self.simulation_name()}_endstate_{int(time.time() * 1000)}.npy"
         print("Saving", name)
-        self.params["setup"]["end_state_filename"] = name
+        self.params["linear_solver_config"]["end_state_filename"] = name
         np.save(name, vals)
 
 
@@ -127,7 +127,7 @@ def make_model(setup: dict):
     porosity = 1.3e-2  # probably on the low side
 
     params = {
-        "setup": setup,
+        "linear_solver_config": setup,
         "folder_name": "visualization_2d_nofrac",
         "material_constants": {
             "solid": pp.SolidConstants(


### PR DESCRIPTION
These improvements ensure that the iterative solver can be called from outside this package, and it can be plugged into existing porepy models with minumal effors. Namely:

* renamed `setup` into `linear_solver_config` and made it optional, providing reasonable defaults.
* Fixed the fixed-stress function in fractures.
* Fixed imports.
* Changed the default amg to gamg, to avoid having Hypre as a dependency.